### PR TITLE
Small change to allow trace spaces on mixedelements

### DIFF
--- a/xii/assembler/trace_form.py
+++ b/xii/assembler/trace_form.py
@@ -19,7 +19,7 @@ def trace_cell(o):
     # Another cell
     cell_name = {'tetrahedron': 'triangle',
                  'triangle': 'interval'}[o.cellname()]
-    
+
     return ufl.Cell(cell_name, o.geometric_dimension())
 
 
@@ -43,11 +43,13 @@ def trace_space(V, mesh):
     # So let's check first for elements where scalar = FiniteElm
     # vector == VectorElm etc
     rank = len(elm.value_shape())
-    if elmtype_map[rank] == type(elm):
-        elm = type(elm)  # I.e. vector element stays verctor element
+    if rank == 1:
+        fs = df.FunctionSpace(mesh, elm(family, mesh.ufl_cell(), degree,
+            dim=V.ufl_element().value_shape()[0]))
     else:
-        elm = elmtype_map[rank]
-    # NOTE: Check out Witze Bonn's work on this and fill more
+        fs = df.FunctionSpace(mesh, elm(family, mesh.ufl_cell(), degree))
+    return fs
+
 
     return df.FunctionSpace(mesh, elm(family, mesh.ufl_cell(), degree))
 
@@ -59,12 +61,12 @@ def Trace(v, mmesh, restriction='', normal=None):
     '''
     # Prevent Trace(grad(u)). But it could be interesting to have this
     assert is_terminal(v)
-    
+
     assert trace_cell(v) == mmesh.ufl_cell()
     # Not sure if it is really needed but will allow 5 types of traces
     assert restriction in ('',      # This makes sense for continuous foos
                            '+',     # For the remaining normal has to be
-                           '-',     # present to get the orientation 
+                           '-',     # present to get the orientation
                            'jump',  # right
                            'avg')
     # A copy!
@@ -75,7 +77,7 @@ def Trace(v, mmesh, restriction='', normal=None):
 
 # Consider now assembly of form, form is really a sum of integrals
 # and here we want to assembly only the trace integrals. A trace integral
-# is one where 
+# is one where
 #
 # 0) the measure is the trace measure
 #

--- a/xii/assembler/trace_form.py
+++ b/xii/assembler/trace_form.py
@@ -43,6 +43,12 @@ def trace_space(V, mesh):
     # So let's check first for elements where scalar = FiniteElm
     # vector == VectorElm etc
     rank = len(elm.value_shape())
+    if elmtype_map[rank] == type(elm):
+        elm = type(elm)  # I.e. vector element stays verctor element
+    else:
+        elm = elmtype_map[rank]
+    # NOTE: Check out Witze Bonn's work on this and fill more
+
     if rank == 1:
         fs = df.FunctionSpace(mesh, elm(family, mesh.ufl_cell(), degree,
             dim=V.ufl_element().value_shape()[0]))

--- a/xii/assembler/trace_form.py
+++ b/xii/assembler/trace_form.py
@@ -56,10 +56,6 @@ def trace_space(V, mesh):
         fs = df.FunctionSpace(mesh, elm(family, mesh.ufl_cell(), degree))
     return fs
 
-
-    return df.FunctionSpace(mesh, elm(family, mesh.ufl_cell(), degree))
-
-
 def Trace(v, mmesh, restriction='', normal=None):
     '''
     Annotated function for being a restriction onto manifold of codimension


### PR DESCRIPTION
Hi! This is a great piece of software. I am interested in using it for solving the Nernst-Planck equation for a set of ion concentrations with an EMI-like boundary. The equations are coupled and require a MixedElement-approach. This small change allows for a mixed element in my case, and should work identically in the previously implemented cases.