### PR TITLE
Some updates for python3 and last dolfin version (2018)

### DIFF
--- a/demo/common.py
+++ b/demo/common.py
@@ -119,7 +119,7 @@ def monitor_error(u, norms, memory, reduction=lambda x: x, path=''):
                        ['|r|_l2=%g' % r_norm] +
                        ['niters=%d' % niters])
         # Screen
-        print GREEN % msg
+        print(GREEN % msg)
         # Log
         if path:
             with open(path, 'a') as f: f.write(msg + '\n')

--- a/xii/assembler/average_form.py
+++ b/xii/assembler/average_form.py
@@ -80,7 +80,7 @@ def Average(v, line_mesh, radius, quadrature_degree=8, surface='cylinder'):
         if hasattr(line_mesh, 'parent_entity_map'):
             assert v_family == 'Lagrange', '3d1d trace undefined for %s' % v_family
         # Otherise the hope is that we will eval in cell interior which
-        print '\tUsing 3d-1d trace!!!!'
+        print('\tUsing 3d-1d trace!!!!')
         
         radius = None  # Signal to avg_mat
         

--- a/xii/assembler/average_matrix.py
+++ b/xii/assembler/average_matrix.py
@@ -326,7 +326,7 @@ if __name__ == '__main__':
     Tf = Function(TV)
     Trace.mult(f.vector(), Tf.vector())
     Tf0.vector().axpy(-1, Tf.vector())
-    print '??', Tf0.vector().norm('linf')
+    print('??', Tf0.vector().norm('linf'))
 
     V = VectorFunctionSpace(mesh, 'CG', 2)
     TV = VectorFunctionSpace(bmesh, 'DG', 1)
@@ -340,7 +340,7 @@ if __name__ == '__main__':
     Tf = Function(TV)
     Trace.mult(f.vector(), Tf.vector())
     Tf0.vector().axpy(-1, Tf.vector())
-    print '??', Tf0.vector().norm('linf')
+    print('??', Tf0.vector().norm('linf'))
 
     # PI
     radius = 0.01
@@ -363,7 +363,7 @@ if __name__ == '__main__':
     Pi.mult(f.vector(), Pi_f.vector())
 
     Pi_f0.vector().axpy(-1, Pi_f.vector())
-    print '>>', Pi_f0.vector().norm('linf')
+    print('>>', Pi_f0.vector().norm('linf'))
 
     V = VectorFunctionSpace(mesh, 'CG', 3)
     Q = VectorFunctionSpace(bmesh, 'DG', 3)
@@ -385,7 +385,8 @@ if __name__ == '__main__':
     Pi.mult(f.vector(), Pi_f.vector())
 
     Pi_f0.vector().axpy(-1, Pi_f.vector())
-    print '>>', Pi_f0.vector().norm('linf')
+
+    print('>>', Pi_f0.vector().norm('linf'))
 
     # Ball
     radius = 0.02
@@ -424,5 +425,5 @@ if __name__ == '__main__':
     Pi.mult(f.vector(), Pi_f.vector())
 
     Pi_f0.vector().axpy(-1, Pi_f.vector())
-    print '>>', Pi_f0.vector().norm('linf')
-    print Pi_f0.vector().get_local()
+    print('>>', Pi_f0.vector().norm('linf'))
+    print(Pi_f0.vector().get_local())

--- a/xii/assembler/fem_eval.py
+++ b/xii/assembler/fem_eval.py
@@ -1,4 +1,4 @@
-from dolfin import Cell, Expression
+from dolfin import Cell, Expression, UserExpression
 import numpy as np
 
 
@@ -43,11 +43,10 @@ class DegreeOfFreedom(object):
         self.__cell = cell_
 
     def eval(self, f):
-        return self.elm.evaluate_dof(self.dof,
-                                     f.as_expression() if isinstance(f, FEBasisFunction) else f,
-                                     self.__cell_vertex_x,
-                                     self.__cell_orientation,
-                                     self.__cell)
+        return self.elm.evaluate_dofs(f.as_expression() if isinstance(f, FEBasisFunction) else f,
+                                      self.__cell_vertex_x,
+                                      self.__cell_orientation,
+                                      self.__cell)[self.dof]
 
 # NOTE: this is a very silly construction. Basically the problem is
 # that Function cannot be properly overloaded beacsue SWIG does not 
@@ -63,7 +62,7 @@ class FEBasisFunction(object):
 
         # A fake instanc to talk to with the world
         adapter = type('MiroHack',
-                       (Expression, ),
+                       (UserExpression, ),
                        {'value_shape': lambda self_, : shape,
                         'eval': lambda self_, values, x: self.eval(values, x)})
         self.__adapter = adapter(degree=degree)
@@ -99,11 +98,10 @@ class FEBasisFunction(object):
         self.__cell = cell_
 
     def eval(self, values, x):
-        self.elm.evaluate_basis(self.dof,
-                                values[:], 
-                                x,
-                                self.__cell_vertex_x,
-                                self.__cell_orientation)
+        values = self.elm.evaluate_basis(self.dof,
+                                         x,
+                                         self.__cell_vertex_x,
+                                         self.__cell_orientation)
 
     def __call__(self, x):
         self.eval(self.__values, x)
@@ -138,7 +136,7 @@ if __name__ == '__main__':
     dofs.cell = cell
     dofs.dof = local_dof
 
-    print dofs.eval(f), dofs.eval(g.as_expression())
+    print(dofs.eval(f), dofs.eval(g.as_expression()))
 
     x = Cell(mesh, cell).midpoint().array()[:2]
-    print f(x), g(x)
+    print(f(x), g(x))

--- a/xii/assembler/nonconforming_trace_matrix.py
+++ b/xii/assembler/nonconforming_trace_matrix.py
@@ -1,7 +1,8 @@
 from xii.linalg.matrix_utils import petsc_serial_matrix
 from xii.assembler.trace_assembly import trace_cell
 from xii.assembler.fem_eval import DegreeOfFreedom, FEBasisFunction
-from dolfin import warning, cells, Point
+from dolfin.cpp import warning
+from dolfin import cells, Point
 from petsc4py import PETSc
 import numpy as np
 

--- a/xii/assembler/reduced_assembler.py
+++ b/xii/assembler/reduced_assembler.py
@@ -8,7 +8,7 @@ import operator
 from xii.assembler.trace_form import *
 from xii.assembler.ufl_utils import *
 import xii.assembler.xii_assembly
-
+from functools import reduce
 
 class ReducedFormAssembler(object):
     '''

--- a/xii/assembler/trace_form.py
+++ b/xii/assembler/trace_form.py
@@ -34,7 +34,7 @@ def trace_element(elm):
     # Want exact match here; otherwise VectorElement is MixedElement and while
     # it works I don't find it pretty
     if type(elm) == df.MixedElement:
-        return df.MixedElement(map(trace_element, elm.sub_elements()))
+        return df.MixedElement(list(map(trace_element, elm.sub_elements())))
     
     # FIXME: Check out Witze Bonn's work on da Rham for trace spaces
     # in the meantime KISS
@@ -94,7 +94,7 @@ def Trace(v, mmesh, restriction='', normal=None):
     # not work this way.
     # FIXME: should Trace(coeffcient) be a coefficient in the trace space right
     # away, what would be changes to the assembler etc?
-    if isinstance(v, df.Coefficient):
+    if isinstance(v, ufl.Coefficient):
         v =  df.Function(v.function_space(), v.vector())
 
     v.trace_ = {'type': restriction, 'mesh': mmesh, 'normal': normal}

--- a/xii/assembler/trace_matrix.py
+++ b/xii/assembler/trace_matrix.py
@@ -3,8 +3,8 @@ from xii.assembler.trace_assembly import trace_cell
 from xii.assembler.fem_eval import DegreeOfFreedom, FEBasisFunction
 from xii.meshing.embedded_mesh import build_embedding_map
 from xii.assembler.nonconforming_trace_matrix import nonconforming_trace_mat
-
-from dolfin import Cell, PETScMatrix, warning
+from dolfin.cpp import warning
+from dolfin import Cell, PETScMatrix
 from petsc4py import PETSc
 import numpy as np
 
@@ -16,7 +16,7 @@ def trace_mat(V, TV, trace_mesh, data):
     understood as D -> D-1.
     '''
     # Compatibility of spaces
-    assert V.dolfin_element().value_rank() == TV.dolfin_element().value_rank()
+    #assert V.dolfin_element().value_rank() == TV.dolfin_element().value_rank()
     assert V.ufl_element().value_shape() == TV.ufl_element().value_shape()
     assert trace_cell(V) == TV.mesh().ufl_cell()
     assert V.mesh().geometry().dim() == TV.mesh().geometry().dim()
@@ -303,12 +303,12 @@ def get_entity_map(mesh, trace_mesh):
     if hasattr(trace_mesh, 'parent_entity_map'):
         # Check if we have the map embedding into mesh
         if mesh_id not in trace_mesh.parent_entity_map:
-            print '\tMissing map for mesh %d' % mesh_id
+            print('\tMissing map for mesh %d' % mesh_id)
             parent_entity_map = build_embedding_map(trace_mesh, mesh)
             trace_mesh.parent_entity_map[mesh_id] = parent_entity_map
     # Compute from scratch and rememeber for future
     else:
-        print '\tComputing embedding map for mesh %d' % mesh_id
+        print('\tComputing embedding map for mesh %d' % mesh_id)
 
         parent_entity_map = build_embedding_map(trace_mesh, mesh)
         # If success we attach it to the mesh (to prevent future recomputing)

--- a/xii/assembler/ufl_utils.py
+++ b/xii/assembler/ufl_utils.py
@@ -1,7 +1,8 @@
-from dolfin.functions.function import Argument
+from dolfin.function.argument import Argument
 from ufl.core.terminal import Terminal
-from itertools import ifilter
+import itertools
 import dolfin as df
+
 
 
 def topological_dim(thing):
@@ -34,12 +35,12 @@ def traverse_terminals(expr):
     '''
     Yield all the termnals (can be duplicate) in the UFL expression tree
     '''
-    return ifilter(is_terminal, traverse(expr))
+    return filter(is_terminal, traverse(expr))
 
 
 def traverse_subexpr(expr):
     '''Yield nodes of the UFL expression tree that have arguments'''
-    return ifilter(lambda e: not is_terminal(e), traverse(expr))
+    return filter(lambda e: not is_terminal(e), traverse(expr))
 
 
 def is_equal_terminal(this, that, attributes=None):

--- a/xii/linalg/__init__.py
+++ b/xii/linalg/__init__.py
@@ -8,6 +8,6 @@ from . function import ii_Function, as_petsc_nest
 try:
     from . hsmg_utils import inverse
 except ImportError:
-    print 'Missing HsMG for fract norm computing'
+    print('Missing HsMG for fract norm computing')
     pass
 

--- a/xii/linalg/block_utils.py
+++ b/xii/linalg/block_utils.py
@@ -340,7 +340,7 @@ if __name__ == '__main__':
 
     z = (R.T)*BB_m*(R*bb)
 
-    print (z - z_block).norm()
+    print((z - z_block).norm())
 
     y  = BB_m*(R*bb)
-    print np.linalg.norm(np.hstack([bi.get_local() for bi in z_block])-y.get_local())
+    print(np.linalg.norm(np.hstack([bi.get_local() for bi in z_block])-y.get_local()))

--- a/xii/linalg/convert.py
+++ b/xii/linalg/convert.py
@@ -4,8 +4,10 @@ from xii.linalg.matrix_utils import (is_petsc_vec, is_petsc_mat, diagonal_matrix
 
 from block.block_compose import block_mul, block_add, block_sub, block_transpose
 from block import block_mat, block_vec
-from dolfin import PETScVector, PETScMatrix, mpi_comm_world
+#from dolfin import PETScVector, PETScMatrix, mpi_comm_world
+from dolfin import PETScVector, PETScMatrix
 from dolfin import Vector, GenericVector, Matrix
+
 from scipy.sparse import bmat as numpy_block_mat
 from scipy.sparse import csr_matrix
 from petsc4py import PETSc
@@ -210,7 +212,7 @@ def block_mat_to_numpy(bmat):
     if is_number(bmat):
         return None  # What bmat accepts
     # Recurse on blocks
-    blocks = np.array(map(block_mat_to_numpy, bmat.blocks.flatten()))
+    blocks = np.array(list(map(block_mat_to_numpy, bmat.blocks.flatten())))
     blocks = blocks.reshape(bmat.blocks.shape)
     # The bmat
     return numpy_block_mat(blocks).tocsr()
@@ -407,12 +409,12 @@ if __name__ == '__main__':
 
     t = Timer('x'); t.start()
     X = convert(AA)
-    print t.stop()
+    print(t.stop())
 
     t = Timer('x'); t.start()
     Y = convert(AA, 'foo')
-    print t.stop()
+    print(t.stop())
 
     X_ = X.array()
     X_[:] -= Y.array()
-    print np.linalg.norm(X_, np.inf)
+    print(np.linalg.norm(X_, np.inf))

--- a/xii/linalg/function.py
+++ b/xii/linalg/function.py
@@ -18,7 +18,7 @@ class ii_Function(object):
     '''Really a list of functions where each is in some W[i]'''
     def __init__(self, W, components=None):
         if components is None:
-            self.functions = map(Function, W)
+            self.functions = list(map(Function, W))
         else:
             assert len(components) == len(W)
             # Functions them selves

--- a/xii/linalg/list_utils.py
+++ b/xii/linalg/list_utils.py
@@ -1,6 +1,7 @@
 # Newly, b = np.array([Vector]) will for some reason call .array of vector
 # b is not an array of vector object but of numbers! As a workaround
 # we'll do things with lists
+from functools import reduce
 
 def shape_list(lst):
     '''Shape of a list (of lists of list)'''
@@ -27,7 +28,8 @@ def flatten_list(lst):
 def reshape_list(lst, shape):
     '''Same as array.reshape'''
     old_shape = shape_list(lst)
-    assert reduce(lambda x, y: x*y, old_shape) == reduce(lambda x, y: x*y, shape)
+    if old_shape is not ():
+        assert reduce(lambda x, y: x*y, old_shape) == reduce(lambda x, y: x*y, shape)
 
     lst = flatten_list(lst)
     while len(shape) > 1:
@@ -39,7 +41,7 @@ def reshape_list(lst, shape):
 
 def package(lst, count):
     '''Break a flat list into pieces with count items'''
-    return [] if not lst else ([lst[:count]] + package(lst[count:], count))
+    return [] if not lst else ([list(lst)[:count]] + package(list(lst)[count:], count))
 
 # --------------------------------------------------------------------
 

--- a/xii/meshing/__init__.py
+++ b/xii/meshing/__init__.py
@@ -1,3 +1,4 @@
-from embedded_mesh import EmbeddedMesh, OuterNormal, InnerNormal
-from subdomain_mesh import SubDomainMesh, OverlapMesh
-from mortar_mesh import mortar_meshes
+from xii.meshing.embedded_mesh import EmbeddedMesh, OuterNormal, InnerNormal
+from xii.meshing.subdomain_mesh import SubDomainMesh, OverlapMesh
+from xii.meshing.mortar_mesh import mortar_meshes
+

--- a/xii/meshing/embedded_mesh.py
+++ b/xii/meshing/embedded_mesh.py
@@ -1,4 +1,4 @@
-from make_mesh_cpp import make_mesh
+from xii.meshing.make_mesh_cpp import make_mesh
 from collections import defaultdict
 from itertools import chain
 import dolfin as df
@@ -104,6 +104,7 @@ class EmbeddedMesh(df.Mesh):
         
         # With acquired data build the mesh
         df.Mesh.__init__(self)
+
         # Fill
         make_mesh(coordinates=vertex_coordinates, cells=new_cells, tdim=tdim, gdim=gdim,
                   mesh=self)
@@ -259,7 +260,7 @@ if __name__ == '__main__':
             rate = np.log(dt/dt0)/np.log(float(n)/n0)
         else:
             rate = np.nan
-        print n, dt, rate
+        print(n, dt, rate)
         n0, dt0 = n, dt
         
     # Check creation

--- a/xii/meshing/mortar_mesh.py
+++ b/xii/meshing/mortar_mesh.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
         
         timer = Timer('x'); timer.start()
         submeshes, interface, colormap = mortar_meshes(subdomains, (0, 1), ifacet_iter)
-        print '\t', timer.stop()
+        print('\t', timer.stop())
     x = interface.parent_entity_map
 
     maps = [build_embedding_map(interface, meshi) for meshi in submeshes]

--- a/xii/nonlin/jacobian.py
+++ b/xii/nonlin/jacobian.py
@@ -1,5 +1,5 @@
 from xii.assembler.ufl_utils import replace as ii_replace
-from itertools import ifilter
+import itertools
 import dolfin as df
 import ufl
 
@@ -54,7 +54,7 @@ def restriction_type(x):
 
 def get_trialfunction(f):
     '''Extract (pointer) to trial function of the object'''
-    return next(ifilter(lambda x: x.number() == 1, f.arguments()))
+    return next(filter(lambda x: x.number() == 1, f.arguments()))
 
 
 def ii_derivative(f, x):


### PR DESCRIPTION
Here are some changes I made hoping to have fenics_ii working with python3 and the last dolfin.
It doesn't work yet, but I share these first changes in case it could be useful.

Note : I have troubles with the `ii_assemble` function. I'm not sure how the recursive call should work but the `assemble` function in `xii_assembly.py` calls the `assemble` function in `reduced_assembler.py` which itself call the first one (of `xii_assembly`), etc.... resulting in a recursion error :  
```
RecursionError: maximum recursion depth exceeded
```